### PR TITLE
Fixed crash in gvr-keyboard sample

### DIFF
--- a/gvr-keyboard/gvrkeyboard/src/main/java/org/gearvrf/keyboard/spinner/SpinnerItem.java
+++ b/gvr-keyboard/gvrkeyboard/src/main/java/org/gearvrf/keyboard/spinner/SpinnerItem.java
@@ -35,13 +35,11 @@ public class SpinnerItem extends TextFieldItem {
 
     @Override
     public void updateText(GVRContext context) {
-        if (cacheTestOn) {
-
-            GVRBitmapTexture tex = new GVRBitmapTexture(context, SpinnerItemFactory.getInstance(
-                    getGVRContext()).getBitmap(charItem.getMode(),
-                    charItem.getPosition()));
-            getRenderData().getMaterial().setMainTexture(tex);
-
+        if (cacheTestOn && (charItem != null)) {
+                GVRBitmapTexture tex = new GVRBitmapTexture(context, SpinnerItemFactory.getInstance(
+                        getGVRContext()).getBitmap(charItem.getMode(),
+                        charItem.getPosition()));
+                getRenderData().getMaterial().setMainTexture(tex);
         } else {
             GVRBitmapTexture tex = new GVRBitmapTexture(context, GVRTextBitmapFactory.create(
                     context.getContext(), width, height, currentText, 0));


### PR DESCRIPTION
Handled the case where the cache test is on and charItem is null
(nothing cached) .
GearVRf-DCO-1.0-Signed-off-by: Nola Donato nola.donato@samsung.com
