### PR TITLE
Fix gvr-scripting demo onStep

### DIFF
--- a/gvr-javascript/app/src/main/assets/script.js
+++ b/gvr-javascript/app/src/main/assets/script.js
@@ -1,5 +1,6 @@
 importPackage(org.gearvrf)
 importPackage(org.gearvrf.scene_objects)
+importPackage(org.gearvrf.script)
 
 function onInit(gvrf) {
   var mainScene = gvrf.getNextMainScene();
@@ -23,7 +24,8 @@ function onInit(gvrf) {
 
   var textSensor = new GVRBaseSensor(gvrf);
   textView.setSensor(textSensor);
-
+  var script = new GVRScriptBehavior(gvrf, "text.js");
+  textView.attachComponent(script);
   mainScene.addSceneObject(textView);
 
   // Animation

--- a/gvr-javascript/app/src/main/assets/script_bundle.json
+++ b/gvr-javascript/app/src/main/assets/script_bundle.json
@@ -10,11 +10,6 @@
 		target: "@GVRActivity",
 		script: "activity.js",
 		language: "js"
-    },
-    {
-		target: "text",
-		script: "text.js",
-		language: "js"
     }
     ]
 }

--- a/gvr-javascript/app/src/main/java/org/gearvrf/sample/gvrjavascript/GearVRJavascriptActivity.java
+++ b/gvr-javascript/app/src/main/java/org/gearvrf/sample/gvrjavascript/GearVRJavascriptActivity.java
@@ -28,8 +28,7 @@ import org.gearvrf.script.GVRScriptManager;
 
 import android.os.Bundle;
 
-public class GearVRJavascriptActivity extends GVRActivity
-{
+public class GearVRJavascriptActivity extends GVRActivity {
     enum DemoMode {
         USE_SINGLE_SCRIPT,
         USE_SCRIPT_BUNDLE,
@@ -38,53 +37,49 @@ public class GearVRJavascriptActivity extends GVRActivity
     // Set the demo mode here
     DemoMode mode = DemoMode.USE_SCRIPT_BUNDLE;
 
-    /** Called when the activity is first created. */
+    /**
+     * Called when the activity is first created.
+     */
     @Override
-    public void onCreate(Bundle savedInstanceState)
-    {
+    public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        
+
         // Instantiate your script class
         // Note: you could just use GVRMain if everything is in lua script
-        GVRMain main = new GearVRJavascriptMain();
+        GearVRJavascriptMain main = new GearVRJavascriptMain();
         setMain(main, "gvr.xml");
- 
+
         GVRScriptManager sm = getGVRContext().getScriptManager();
 
         // Add utils for scripts
         sm.addVariable("utils", new ScriptUtils());
 
         switch (mode) {
-        case USE_SINGLE_SCRIPT: {
-            // Attach a script file directly (without using a GVRScriptBundle)
-            GVRScriptFile scriptFile;
-            try {
-                scriptFile = sm.loadScript(
-                        new GVRAndroidResource(getGVRContext(), "script.js"),
-                        GVRScriptManager.LANG_JAVASCRIPT);
-                sm.attachScriptFile(main, scriptFile);
-            } catch (IOException e) {
-                e.printStackTrace();
-            } catch (GVRScriptException e) {
-                e.printStackTrace();
+            case USE_SINGLE_SCRIPT: {
+                // Attach a script file directly (without using a GVRScriptBundle)
+                GVRScriptFile scriptFile;
+                try {
+                    scriptFile = sm.loadScript(
+                            new GVRAndroidResource(getGVRContext(), "script.js"),
+                            GVRScriptManager.LANG_JAVASCRIPT);
+                    sm.attachScriptFile(main, scriptFile);
+                } catch (IOException | GVRScriptException e) {
+                    e.printStackTrace();
+                }
+                break;
             }
-            break;
-        }
 
-        case USE_SCRIPT_BUNDLE: {
-            // Load a script bundle
-            GVRScriptBundle scriptBundle;
-            try {
-                scriptBundle = sm.loadScriptBundle("script_bundle.json",
-                        new GVRResourceVolume(getGVRContext(), GVRResourceVolume.VolumeType.ANDROID_ASSETS));
-                sm.bindScriptBundle(scriptBundle, main, true);
-            } catch (IOException e) {
-                e.printStackTrace();
-            } catch (GVRScriptException e) {
-                e.printStackTrace();
+            case USE_SCRIPT_BUNDLE: {
+                // Load a script bundle
+                GVRScriptBundle scriptBundle;
+                try {
+                    scriptBundle = sm.loadScriptBundle("script_bundle.json",
+                            new GVRResourceVolume(getGVRContext(), GVRResourceVolume.VolumeType.ANDROID_ASSETS));
+                    sm.bindScriptBundle(scriptBundle, main, true);
+                } catch (IOException | GVRScriptException e) {
+                    e.printStackTrace();
+                }
             }
-            break;
-        }
         }
     }
 }

--- a/gvr-javascript/app/src/main/java/org/gearvrf/sample/gvrjavascript/GearVRJavascriptMain.java
+++ b/gvr-javascript/app/src/main/java/org/gearvrf/sample/gvrjavascript/GearVRJavascriptMain.java
@@ -22,10 +22,16 @@ import org.gearvrf.GVRRenderData;
 import org.gearvrf.GVRScene;
 import org.gearvrf.GVRSceneObject;
 import org.gearvrf.GVRMain;
+import org.gearvrf.IScriptEvents;
 import org.gearvrf.io.CursorControllerListener;
 import org.gearvrf.io.GVRControllerType;
 import org.gearvrf.io.GVRInputManager;
 import org.gearvrf.scene_objects.GVRSphereSceneObject;
+import org.gearvrf.script.GVRScriptBundle;
+import org.gearvrf.script.GVRScriptException;
+import org.gearvrf.script.GVRScriptManager;
+
+import java.io.IOException;
 
 public class GearVRJavascriptMain extends GVRMain {
     private static final String TAG = GearVRJavascriptMain.class.getSimpleName();


### PR DESCRIPTION
Fixes problem cause by PR #776
The script bundle is attached really early in onCreate and it can't find
the "text" scene object when it tries to attach the bundle. I changed
one of the scripts to attach "text.js" to the "text" scene object
programatically instead of in the bundle. Now the onSensorEvent and
onStep functions get called.

GearVRf-DCO-1.0-Signed-off-by: Nola Donato nola.donato@samsung.com
